### PR TITLE
Improve comps group support

### DIFF
--- a/dnfdragora/compsicons.py
+++ b/dnfdragora/compsicons.py
@@ -1,0 +1,48 @@
+from gettext import gettext as _
+import os.path
+
+class CompsIcons:
+    '''
+    This class manages the access to group name and icons
+    '''
+    def __init__(self, icon_path=None):
+
+        if icon_path:
+            self.icon_path = icon_path if icon_path.endswith("/") else icon_path + "/"
+        else:
+            self.icon_path = "/usr/share/pixmaps/comps/"
+
+        self.default_icon = self.icon_path + "uncategorized.png"
+
+        # workaround for https://github.com/timlau/dnf-daemon/issues/9
+        # generated using tools/gen-comps-category-list.sh
+        self.name_to_id_map = {
+            "KDE Desktop": "kde-desktop-environment",
+            "Xfce Desktop": "xfce-desktop-environment",
+            "Applications": "apps",
+            "LXDE Desktop": "lxde-desktop-environment",
+            "LXQt Desktop": "lxqt-desktop-environment",
+            "Cinnamon Desktop": "cinnamon-desktop-environment",
+            "MATE Desktop": "mate-desktop-environment",
+            "Hawaii Desktop": "hawaii-desktop-environment",
+            "Sugar Desktop Environment": "sugar-desktop-environment",
+            "GNOME Desktop": "gnome-desktop-environment",
+            "Development": "development",
+            "Servers": "servers",
+            "Base System": "base-system",
+            "Content": "content",
+            }
+
+    def icon(self, group_path):
+        group_names = group_path.split("/")
+        for group_name in reversed(group_names):
+            if group_name in self.name_to_id_map:
+                group_id = self.name_to_id_map[group_name]
+            else:
+                group_id = group_name
+
+            icon_name = self.icon_path + group_id + ".png"
+            if os.path.exists(icon_name):
+                return icon_name
+
+        return self.default_icon

--- a/tools/gen-comps-category-list.sh
+++ b/tools/gen-comps-category-list.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Generate the map from category name to ID for dnfdragora/compsicons.py
+# Workaround for https://github.com/timlau/dnf-daemon/issues/9
+wget https://pagure.io/fedora-comps/raw/master/f/comps-f26.xml.in -q -O - | tr '\n' '#' | sed -e 's!<group>.*</group>!!g' -e 's!<environment>.*</environment>!!g' | tr '#' '\n' | grep '<_name>\|<id>' | tr '\n' '#' | sed -e 's!<id>\([^<]*\)</id># *<_name>\([^<]*\)</_name>!"\2": "\1",!g' | tr '#' '\n' | sed -e 's/^ */            /g'


### PR DESCRIPTION
New file dnfdragora/compsicons.py, similar to groupicons.py, but for comps.

New tool tools/gen-comps-category-list.sh: Generates a map from category name to ID for dnfdragora/compsicons.py, as a workaround for timlau/dnf-daemon#9.

dnfdragora/ui.py (mainGui._getAllGroupIDList): Remember the UI names for each ID in an `id_to_name_map`.
                 (mainGui._fillGroupTree): Handle comps separately, use compsicons.py to get the icons (#2) and use the `id_to_name_map` to get the UI name (#3).

Fixes #2.
Fixes #3.

The only remaining issue is that the UI names are not translated, which I filed as timlau/dnf-daemon#10 because Yumex-DNF is also affected (and thus it is clearly dnfdaemon's fault).